### PR TITLE
Update permission strings

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -641,9 +641,9 @@ PlayerSettings:
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1
   enableCrashReportAPI: 0
-  cameraUsageDescription: Not Used
+  cameraUsageDescription: 
   locationUsageDescription: 
-  microphoneUsageDescription: Not Used
+  microphoneUsageDescription: Microphone is used for voice chat in Multiplayer mode
   bluetoothUsageDescription: 
   macOSTargetOSVersion: 10.13.0
   switchNMETAOverride: 


### PR DESCRIPTION
Use an empty string rather than "Not Used" for camera - the Zapbox SDK fills in a default if this is unset.

Add a descriptive permission string for microphone usage.

The microphone one in particular will likely come up in app review; it pops up straight away even before controllers are paired so the Apple reviewers will likely notice, and the quality of permission strings is often a reason for failed app reviews.